### PR TITLE
Add chat UI and message helpers

### DIFF
--- a/veilid-chat-inline.html
+++ b/veilid-chat-inline.html
@@ -150,6 +150,13 @@
       </div>
       <div class="row"><label class="muted">Derived key</label><span id="recKey" class="pill mono">—</span></div>
       <div class="row"><label class="muted">Schema mode</label><span id="schemaMode" class="pill mono">not-detected</span></div>
+      <div id="roomChatUI" style="display:none">
+        <div id="roomChatLog" class="mono" style="background:#0b0e12;padding:6px;margin:8px 0;height:120px;overflow:auto"></div>
+        <div class="row">
+          <input id="txtRoomMsg" type="text" placeholder="Message" style="flex:1">
+          <button id="btnSendRoom" disabled>Send</button>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -165,6 +172,13 @@
           <button id="btnExport" disabled>My private route</button>
           <input id="txtPeerRoute" type="text" placeholder="Peer route" style="width:60%">
           <button id="btnImport" disabled>Connect</button>
+        </div>
+      </div>
+      <div id="routeChatUI" style="display:none">
+        <div id="routeChatLog" class="mono" style="background:#0b0e12;padding:6px;margin:8px 0;height:120px;overflow:auto"></div>
+        <div class="row">
+          <input id="txtRouteMsg" type="text" placeholder="Message" style="flex:1">
+          <button id="btnSendRoute" disabled>Send</button>
         </div>
       </div>
     </div>
@@ -228,6 +242,15 @@ const routePanel       = document.getElementById('routePanel');
 const btnExport        = document.getElementById('btnExport');
 const btnImport        = document.getElementById('btnImport');
 const txtPeerRoute     = document.getElementById('txtPeerRoute');
+// Chat UI elements
+const roomChatUI       = document.getElementById('roomChatUI');
+const roomChatLog      = document.getElementById('roomChatLog');
+const txtRoomMsg       = document.getElementById('txtRoomMsg');
+const btnSendRoom      = document.getElementById('btnSendRoom');
+const routeChatUI      = document.getElementById('routeChatUI');
+const routeChatLog     = document.getElementById('routeChatLog');
+const txtRouteMsg      = document.getElementById('txtRouteMsg');
+const btnSendRoute     = document.getElementById('btnSendRoute');
 
 const rtsrcRadios = [...document.querySelectorAll('input[name="rtsrc"]')];
 const srcFiles    = document.getElementById('srcFiles');
@@ -243,6 +266,8 @@ let attached = false;
 let reachable = [];
 let schemaStrategy = null;
 let hasRouteExport = false;
+let currentRoomKey = null;
+let peerConnected = false;
 
 tagUA.textContent = navigator.userAgent;
 tagCtx.textContent = `protocol=${location.protocol.replace(':','')}, secure=${window.isSecureContext}`;
@@ -432,6 +457,10 @@ function unloadRuntime() {
   btnJoin.disabled = true;
   btnExport.disabled = true;
   btnImport.disabled = true;
+  btnSendRoom.disabled = true;
+  btnSendRoute.disabled = true;
+  roomChatUI.style.display = "none"; roomChatLog.textContent = ""; currentRoomKey = null;
+  routeChatUI.style.display = "none"; routeChatLog.textContent = ""; peerConnected = false;
   kvExports.textContent = "—";
   tagVer.textContent = "runtime: not loaded";
   tagStatus.textContent = "idle";
@@ -561,11 +590,16 @@ async function doAttach() {
 }
 async function doDetach() {
   log("detach() called");
-  try{ await wasm.detach?.(); btnDetach.disabled = true; btnJoin.disabled = true; btnExport.disabled = true; btnImport.disabled = true; }catch(e){ log(`detach error: ${j(e)}`); }
+  try{
+    await wasm.detach?.();
+    btnDetach.disabled = true; btnJoin.disabled = true; btnExport.disabled = true; btnImport.disabled = true;
+    roomChatUI.style.display = "none"; btnSendRoom.disabled = true; currentRoomKey = null;
+    routeChatUI.style.display = "none"; btnSendRoute.disabled = true; peerConnected = false;
+  }catch(e){ log(`detach error: ${j(e)}`); }
 }
 
 /*** DHT schema compatibility ***/
-function pickSchemaStrategy() {
+async function pickSchemaStrategy() {
   if (schemaStrategy) return schemaStrategy;
   if (!ctx || !ctx.getDhtRecordKey) throw new Error("getDhtRecordKey not available");
   const candidates = [
@@ -577,13 +611,13 @@ function pickSchemaStrategy() {
     { name: "tag-Type-App", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"App", app:ns}, kind, name) },
   ];
   for (const c of candidates) {
-    try { const k=c.fn("__probe__","room","hello"); if (k) { schemaStrategy=c; schemaModeEl.textContent=c.name; return c; } } catch {}
+    try { const k = await Promise.resolve(c.fn("__probe__","room","hello")); if (k) { schemaStrategy=c; schemaModeEl.textContent=c.name; return c; } } catch {}
   }
   throw new Error("Could not determine DHTSchema tagging for this runtime");
 }
-function deriveRecordKey(ns, kind, name) {
-  const strat = pickSchemaStrategy();
-  return strat.fn(ns, kind, name);
+async function deriveRecordKey(ns, kind, name) {
+  const strat = await pickSchemaStrategy();
+  return await Promise.resolve(strat.fn(ns, kind, name));
 }
 
 /*** Room join/leave ***/
@@ -592,18 +626,26 @@ async function joinRoom() {
   const ns=(nsEl.value||"").trim(), kind=(kindEl.value||"").trim(), name=(roomEl.value||"").trim();
   if (!ns || !kind || !name) { log("Join room error: namespace/kind/room are required."); return; }
   try{
-    const key = deriveRecordKey(ns, kind, name);
+    const key = await deriveRecordKey(ns, kind, name);
     recKeyEl.textContent = typeof key === "string" ? key : JSON.stringify(key);
     log(`Room key derived ok. schemaMode=${schemaStrategy?.name}`);
     if (!ctx) ctx = new (wasm?.VeilidRoutingContext)();
     try { await ctx.createDhtRecord?.(key); log("createDhtRecord ok (or already existed)"); } catch(e){ log(`createDhtRecord: ${e?.message||e}`); }
     try { await ctx.openDhtRecord?.(key);   log("openDhtRecord ok"); }                   catch(e){ log(`openDhtRecord: ${e?.message||e}`); }
+    currentRoomKey = key;
+    roomChatUI.style.display = "";
+    roomChatLog.textContent = "";
+    btnSendRoom.disabled = false;
     btnLeave.disabled=false; btnJoin.disabled=true;
   }catch(e){ log(`Join room error: ${e?.message||e}`); }
 }
 async function leaveRoom(){
   recKeyEl.textContent = "—";
   schemaModeEl.textContent = schemaStrategy? schemaStrategy.name : "not-detected";
+  currentRoomKey = null;
+  roomChatUI.style.display = "none";
+  roomChatLog.textContent = "";
+  btnSendRoom.disabled = true;
   btnLeave.disabled=true; btnJoin.disabled=false;
 }
 
@@ -629,8 +671,45 @@ async function importPeerRoute(){
   try {
     await fn.call(wasm, route);
     log("import route ok");
+    peerConnected = true;
+    routeChatUI.style.display = "";
+    routeChatLog.textContent = "";
+    btnSendRoute.disabled = false;
   } catch (e) {
     log(`import route error: ${e?.message||e}`);
+  }
+}
+
+/*** Chat send helpers ***/
+async function sendRoomMsg(){
+  if (!currentRoomKey) { log("Room message error: not in room"); return; }
+  const msg = (txtRoomMsg.value||"").trim();
+  if (!msg) return;
+  const data = new TextEncoder().encode(msg);
+  const fn = ctx?.setDhtRecordValue || ctx?.writeDhtRecordValue || ctx?.appendDhtRecordValue;
+  if (!fn) { log("DHT write not available"); return; }
+  try {
+    await fn.call(ctx, currentRoomKey, data);
+    roomChatLog.textContent += `me: ${msg}\n`;
+    txtRoomMsg.value = "";
+  } catch (e) {
+    log(`Room message error: ${e?.message||e}`);
+  }
+}
+async function sendRouteMsg(){
+  if (!peerConnected) { log("Route message error: no peer route"); return; }
+  const msg = (txtRouteMsg.value||"").trim();
+  if (!msg) return;
+  const data = new TextEncoder().encode(msg);
+  const sendFns = ['sendPrivateMessage','send_message','routeSend','sendMessage','send'];
+  const fn = sendFns.map(n=>ctx?.[n]).find(Boolean) || wasm?.send_private_message || wasm?.sendMessage;
+  if (!fn) { log("Route send not available"); return; }
+  try {
+    await fn.call(ctx||wasm, data);
+    routeChatLog.textContent += `me: ${msg}\n`;
+    txtRouteMsg.value = "";
+  } catch (e) {
+    log(`Route message error: ${e?.message||e}`);
   }
 }
 
@@ -646,6 +725,8 @@ document.getElementById('btnJoin').onclick    = joinRoom;
 document.getElementById('btnLeave').onclick   = leaveRoom;
 document.getElementById('btnExport').onclick  = exportMyRoute;
 document.getElementById('btnImport').onclick  = importPeerRoute;
+document.getElementById('btnSendRoom').onclick= sendRoomMsg;
+document.getElementById('btnSendRoute').onclick= sendRouteMsg;
 
 document.getElementById('chkReachables').onchange  = e=> log(`Use only reachables: ${e.target.checked}`);
 document.getElementById('chkForceWSS').onchange    = e=> log(`Force WSS ${e.target.checked ? "enabled" : "disabled"}`);


### PR DESCRIPTION
## Summary
- Add room and private-route chat panels with send controls
- Track active room and peer connections in global state
- Provide message helpers and wire up send buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b789b1ff5c83258ac303ea7d841729