### PR TITLE
fix: handle kind in record key descriptor

### DIFF
--- a/veilid-chat-inline.html
+++ b/veilid-chat-inline.html
@@ -625,11 +625,19 @@ async function pickSchemaStrategy() {
   if (!ctx || !ctx.getDhtRecordKey) throw new Error("getDhtRecordKey not available");
   // Try object/tagged forms first to avoid console noise on runtimes that don't accept plain strings.
   const candidates = [
+    // Single object forms that include kind + name
+    { name: "obj-type-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"namespace", namespace:ns, kind, name}) },
+    { name: "obj-Type-Namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"Namespace", namespace:ns, kind, name}) },
+    { name: "obj-schema-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({schema:"namespace", namespace:ns, kind, name}) },
+    { name: "obj-type-app", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"app", app:ns, kind, name}) },
+    { name: "obj-Type-App", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"App", app:ns, kind, name}) },
+    // Tagged object plus separate kind/name
     { name: "tag-type-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"namespace", namespace:ns}, kind, name) },
     { name: "tag-Type-Namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"Namespace", namespace:ns}, kind, name) },
     { name: "tag-schema-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({schema:"namespace", namespace:ns}, kind, name) },
     { name: "tag-type-app", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"app", app:ns}, kind, name) },
     { name: "tag-Type-App", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"App", app:ns}, kind, name) },
+    // Plain strings
     { name: "plain-strings", fn: (ns,kind,name)=>ctx.getDhtRecordKey(ns,kind,name) },
   ];
   for (const c of candidates) {


### PR DESCRIPTION
## Summary
- add compatibility for runtimes expecting getDhtRecordKey to receive a single object including `kind`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b78f670f088325a30c26542c9add86