### PR TITLE
Fix runtime schema detection error handling

### DIFF
--- a/veilid-chat-inline.html
+++ b/veilid-chat-inline.html
@@ -643,9 +643,15 @@ async function pickSchemaStrategy() {
   for (const c of candidates) {
     let k = null;
     try {
-      k = await Promise.resolve(c.fn("__probe__","room","hello")).catch(()=>null);
-    } catch {}
-    if (k) { schemaStrategy=c; schemaModeEl.textContent=c.name; return c; }
+      k = await c.fn("__probe__", "room", "hello");
+    } catch (e) {
+      continue;
+    }
+    if (k) {
+      schemaStrategy = c;
+      schemaModeEl.textContent = c.name;
+      return c;
+    }
   }
   throw new Error("Could not determine DHTSchema tagging for this runtime");
 }


### PR DESCRIPTION
## Summary
- avoid unhandled `getDhtRecordKey` errors when detecting DHT schema

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b791a01d2083258daf0dda910a8e47