### PR TITLE
Improve DHT schema detection for record key generation

### DIFF
--- a/veilid-chat-inline.html
+++ b/veilid-chat-inline.html
@@ -626,12 +626,16 @@ async function pickSchemaStrategy() {
   // Try object/tagged forms first to avoid console noise on runtimes that don't accept plain strings.
   const candidates = [
     // Single object forms that include kind + name
+    { name: "obj-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({namespace:ns, kind, name}) },
+    { name: "obj-app", fn: (ns,kind,name)=>ctx.getDhtRecordKey({app:ns, kind, name}) },
     { name: "obj-type-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"namespace", namespace:ns, kind, name}) },
     { name: "obj-Type-Namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"Namespace", namespace:ns, kind, name}) },
     { name: "obj-schema-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({schema:"namespace", namespace:ns, kind, name}) },
     { name: "obj-type-app", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"app", app:ns, kind, name}) },
     { name: "obj-Type-App", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"App", app:ns, kind, name}) },
     // Tagged object plus separate kind/name
+    { name: "tag-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({namespace:ns}, kind, name) },
+    { name: "tag-app", fn: (ns,kind,name)=>ctx.getDhtRecordKey({app:ns}, kind, name) },
     { name: "tag-type-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"namespace", namespace:ns}, kind, name) },
     { name: "tag-Type-Namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({type:"Namespace", namespace:ns}, kind, name) },
     { name: "tag-schema-namespace", fn: (ns,kind,name)=>ctx.getDhtRecordKey({schema:"namespace", namespace:ns}, kind, name) },


### PR DESCRIPTION
## Summary
- broaden DHT record key schema detection to cover namespace/app forms
- avoid missing `kind` errors when joining rooms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79302870483258ea4409633b73012