### PR TITLE
feat: add local persistence utilities

### DIFF
--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -6,7 +6,7 @@ The project is organized into nine milestones building toward a single‑file Ve
 2. [x] **Load Veilid example** – initialize WASM and expose `veilid` global.
 3. [x] **Embed WASM** – Base64 embed of glue and WASM; dynamic loader.
 4. [x] **Connectivity** – bootstrap probing, attach lifecycle, peer stats.
-5. [ ] **Persistence** – identity, contacts, rooms stored locally.
+5. [x] **Persistence** – identity, contacts, rooms stored locally.
 6. [ ] **Rooms via DHT** – multi‑writer room chat with watch/send.
 7. [ ] **Private routes** – 1:1 routing with DHT fallback.
 8. [ ] **Groups** – group membership, roles, and fanout messaging.

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import { init } from './wasm-embedded.js';
 import { bootstrapProbe, attach, detach, peerStats } from './net.js';
+import { loadIdentity, saveIdentity } from './store.js';
 
 console.log('App boot');
 
@@ -7,6 +8,12 @@ let handle;
 
 init().then(async () => {
   console.log('Veilid initialized', window.veilid);
+  let identity = loadIdentity();
+  if (!identity) {
+    identity = crypto.randomUUID();
+    saveIdentity(identity);
+  }
+  console.log('Identity', identity);
   await bootstrapProbe();
   handle = await attach();
   const stats = await peerStats();

--- a/src/store.js
+++ b/src/store.js
@@ -1,1 +1,65 @@
-// persistence utilities will go here
+const PREFIX = 'vic_';
+
+function load(key, fallback) {
+  const raw = localStorage.getItem(PREFIX + key);
+  if (raw == null) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function save(key, value) {
+  localStorage.setItem(PREFIX + key, JSON.stringify(value));
+}
+
+export function loadIdentity() {
+  return load('identity', null);
+}
+
+export function saveIdentity(id) {
+  save('identity', id);
+}
+
+export function loadContacts() {
+  return load('contacts', []);
+}
+
+export function saveContacts(list) {
+  save('contacts', list);
+}
+
+export function loadRooms() {
+  return load('rooms', []);
+}
+
+export function saveRooms(list) {
+  save('rooms', list);
+}
+
+export function addContact(contact) {
+  const list = loadContacts();
+  list.push(contact);
+  saveContacts(list);
+  return list;
+}
+
+export function removeContact(contact) {
+  const list = loadContacts().filter(c => c !== contact);
+  saveContacts(list);
+  return list;
+}
+
+export function addRoom(room) {
+  const list = loadRooms();
+  list.push(room);
+  saveRooms(list);
+  return list;
+}
+
+export function removeRoom(room) {
+  const list = loadRooms().filter(r => r !== room);
+  saveRooms(list);
+  return list;
+}


### PR DESCRIPTION
## Summary
- add localStorage-backed store module for identities, contacts, and rooms
- persist identity during app bootstrap
- update timeline for completed persistence milestone

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b89fc704f483258a0eb6a70238872f