### PR TITLE
Inline build output and fix dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "npx http-server public -p 5173",
+    "dev": "npx http-server . -p 5173",
     "build": "node tools/embed-wasm.js && node tools/make-single-file.js"
   },
   "dependencies": {},

--- a/tools/make-single-file.js
+++ b/tools/make-single-file.js
@@ -1,7 +1,44 @@
-// placeholder single-file builder
 import { readFile, writeFile, mkdir } from 'fs/promises';
+import { resolve, dirname } from 'path';
+
+async function bundle(entry) {
+  const visited = new Set();
+
+  async function load(file) {
+    file = resolve(file);
+    if (visited.has(file)) return '';
+    visited.add(file);
+
+    let code = await readFile(file, 'utf8');
+    const dir = dirname(file);
+    const importRE = /^import\s+[^'"`]+['"]([^'"`]+)['"];?\n?/gm;
+    const deps = [];
+    code = code.replace(importRE, (_m, spec) => {
+      if (spec.startsWith('.')) {
+        deps.push(resolve(dir, spec));
+        return '';
+      }
+      return _m;
+    });
+
+    code = code.replace(/^export\s+(?:default\s+)?/gm, '');
+
+    let out = '';
+    for (const dep of deps) {
+      out += await load(dep);
+    }
+    out += '\n' + code;
+    return out;
+  }
+
+  return load(entry);
+}
 
 await mkdir('dist', { recursive: true });
 const template = await readFile('public/index.template.html', 'utf8');
-await writeFile('dist/index.html', template);
-console.log('Wrote dist/index.html (placeholder)');
+const bundled = await bundle('src/app.js');
+const scriptTag = '<script type="module" src="../src/app.js"></script>';
+const html = template.replace(scriptTag, `<script type="module">\n${bundled}\n</script>`);
+await writeFile('dist/index.html', html);
+console.log('Wrote dist/index.html');
+


### PR DESCRIPTION
## Summary
- Serve repository root during development to expose source modules
- Bundle app modules into a single inline script for final HTML builds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8a215b1b88325b4bca8f0016ad989